### PR TITLE
Add the ability to provide configuration via yaml files

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -1,0 +1,40 @@
+package configuration
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Metrics represents the static configuration of a metric entity from Base
+type Metrics struct {
+	Name         string   `yaml:"name"`
+	RemoveMetric bool     `yaml:"remove_metric"`
+	RemoveTags   []string `yaml:"remove_tags"`
+	RemoveHost   bool     `yaml:"remove_host"`
+}
+
+// Base represents the static configuration read from yaml file
+type Base struct {
+	Metrics       []Metrics `yaml:"metrics"`
+	RemoveAllHost bool      `yaml:"remove_all_host"`
+	Port          int       `yaml:"port"`
+}
+
+// Parse takes the config location, parses the yaml and
+// returns Config struct represenation of the same
+func Parse(fileLocation string) (cfg *Base, e error) {
+	f, err := os.Open(fileLocation)
+	if err != nil {
+		return cfg, err
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	err = decoder.Decode(&cfg)
+	if err != nil {
+		return cfg, err
+	}
+
+	return cfg, nil
+}

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -1,0 +1,50 @@
+package configuration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseInValidFile(t *testing.T) {
+	_, err := Parse("test_data/bad_config.yml")
+
+	if err == nil {
+		t.Errorf("No error raised. Expected: %s", err)
+	}
+}
+
+func TestParseValidFile(t *testing.T) {
+	cfg, err := Parse("test_data/good_config.yml")
+
+	if err != nil {
+		t.Errorf("Exception raised %s", err)
+	}
+
+	expectedCfg := &Base{
+		Port: 9000,
+		Metrics: []Metrics{
+			{
+				Name:         "request.200",
+				RemoveMetric: true,
+				RemoveTags:   []string{"some-tags"},
+				RemoveHost:   true,
+			},
+		},
+		RemoveAllHost: true,
+	}
+
+	if !reflect.DeepEqual(cfg, expectedCfg) {
+		t.Errorf("Structs didn't match. Recieved: %v. Expected: %vs", cfg, expectedCfg)
+	}
+}
+
+func TestParseNoValidFile(t *testing.T) {
+	_, err := Parse("foo-bar.yml")
+
+	if err == nil {
+		t.Error("No error raised")
+	}
+	if err.Error() != "open foo-bar.yml: no such file or directory" {
+		t.Errorf("Unexpected exception raised. Expecting a no file found error %s", err)
+	}
+}

--- a/configuration/test_data/bad_config.yml
+++ b/configuration/test_data/bad_config.yml
@@ -1,0 +1,14 @@
+
+metrics
+dfsdfsd:
+-
+    name: "something"
+    remove_metric: true # removes the entire metric line from payload, altogether.
+    remove_tags: # removes tags from the respective metric line in the payload.
+      - "some-tags"
+      - ""
+    remove_host: true # removes host from the respective metric line in the payload.
+
+
+no_host_tags: true
+port: 9000 # port to dogstatsd-sift on

--- a/configuration/test_data/good_config.yml
+++ b/configuration/test_data/good_config.yml
@@ -1,0 +1,11 @@
+
+metrics:
+  -
+    name: "request.200"
+    remove_metric: true # removes the entire metric line from payload, altogether.
+    remove_tags: # removes tags from the respective metric line in the payload.
+      - "some-tags"
+    remove_host: true # removes host from the respective metric line in the payload.
+
+remove_all_host: true
+port: 9000 # port to dogstatsd-sift on

--- a/example.yml
+++ b/example.yml
@@ -1,0 +1,21 @@
+
+metrics:
+  -
+    name: "something"
+    remove_metric: true # removes the entire metric line from payload, altogether.
+    remove_tags: # removes tags from the respective metric line in the payload.
+      - "some-tags"
+      - ""
+    remove_host: true # removes host from the respective metric line in the payload.
+  -
+    name: "something"
+    remove_metric: true # removes the entire metric line from payload, altogether.
+    remove_tags: # removes tags from the respective metric line in the payload.
+      - "some-tags"
+      - ""
+    remove_host: true # removes host from the respective metric line in the payload.
+
+
+no_host_tags: true
+
+port: 9000 # port to dogstatsd-sift on

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/shayonj/dogstatsd-sift
 
 go 1.13
 
-require github.com/sirupsen/logrus v1.4.2
+require (
+	github.com/sirupsen/logrus v1.4.2
+	gopkg.in/yaml.v2 v2.2.7
+)

--- a/go.sum
+++ b/go.sum
@@ -11,3 +11,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
With this configuration, it is now easy to provide instructions on how certain
metrics/tags/host values should be treated. Based on the config, one can now
remove metric, tags or host on the fly, just based on the metric name